### PR TITLE
Remove value of `pluginUntilBuild`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.0.7
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 222.*
-pluginUntilBuild = 231.*
+pluginUntilBuild = 
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
Removing the value of `pluginUntilBuild` will mean that the plugin will automatically be available on future version of IntelliJ IDEs.

I’m currently seeing this error running PhpStorm 2023.2 EAP:
 
<img width="493" alt="Screenshot 2023-07-04 at 18 11 42" src="https://github.com/hugohomesquita/htmx-jetbrains/assets/57572400/51792c15-828b-42fd-9487-b7cac144b87d">
