### PR TITLE
Add hx-swap-oob suggested values

### DIFF
--- a/src/main/kotlin/com/github/hugohomesquita/htmxjetbrains/HtmxCompletionContributor.kt
+++ b/src/main/kotlin/com/github/hugohomesquita/htmxjetbrains/HtmxCompletionContributor.kt
@@ -1,6 +1,7 @@
 package com.github.hugohomesquita.htmxjetbrains
 
 import com.github.hugohomesquita.htmxjetbrains.completion.HxSwapCompletion
+import com.github.hugohomesquita.htmxjetbrains.completion.HxSwapOobCompletion
 import com.github.hugohomesquita.htmxjetbrains.completion.HxTargetCompletion
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionType
@@ -28,6 +29,13 @@ class HtmxCompletionContributor : CompletionContributor() {
                 .psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
                 .inside(XmlPatterns.xmlAttribute("hx-swap")),
             HxSwapCompletion()
+        )
+        extend(
+            CompletionType.BASIC,
+            PlatformPatterns
+                .psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
+                .inside(XmlPatterns.xmlAttribute("hx-swap-oob")),
+            HxSwapOobCompletion()
         )
     }
 }

--- a/src/main/kotlin/com/github/hugohomesquita/htmxjetbrains/completion/HxSwapOobCompletion.kt
+++ b/src/main/kotlin/com/github/hugohomesquita/htmxjetbrains/completion/HxSwapOobCompletion.kt
@@ -1,0 +1,39 @@
+package com.github.hugohomesquita.htmxjetbrains.completion
+
+import com.github.hugohomesquita.htmxjetbrains.Htmx
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.html.HTMLLanguage
+import com.intellij.util.ProcessingContext
+
+class HxSwapOobCompletion : CompletionProvider<CompletionParameters?>() {
+    override fun addCompletions(
+        parameters: CompletionParameters,
+        context: ProcessingContext,
+        result: CompletionResultSet
+    ) {
+        val position = parameters.position
+
+        if (HTMLLanguage.INSTANCE !in position.containingFile.viewProvider.languages) {
+            return
+        }
+
+        val options = hashMapOf(
+            "innerHTML" to "The default, replace the inner html of the target element",
+            "outerHTML" to "Replace the entire target element with the response",
+            "true" to "Equivalent to 'outerHTML'",
+            "beforebegin" to "Insert the response before the target element",
+            "afterbegin" to "Insert the response before the first child of the target element",
+            "beforeend" to "Insert the response after the last child of the target element",
+            "afterend" to "Insert the response after the target element",
+            "delete" to "Deletes the target element regardless of the response",
+            "none" to "Does not append content from response (out of band items will still be processed)."
+        )
+
+        options.map { (key, value) ->
+            LookupElementBuilder.create(key).withIcon(Htmx.ICON).withTypeText(value)
+        }.forEach { result.addElement(it) }
+    }
+}


### PR DESCRIPTION
Per the docs, hx-swap-oob accepts all the same values of hx-swap, along with the "true" flag: https://htmx.org/attributes/hx-swap-oob/

This change does not implement the 3rd option of "any valid hx-swap value, followed by a colon, followed by a CSS selector".  Likely the hx-target code could be reused to help populate this list, b ut I wanted some basic values in here.